### PR TITLE
make command work in contao 4.9

### DIFF
--- a/src/Command/OptimizeImagesCommand.php
+++ b/src/Command/OptimizeImagesCommand.php
@@ -6,7 +6,8 @@ use InvalidArgumentException;
 use Spatie\ImageOptimizer\OptimizerChain;
 use Spatie\ImageOptimizer\OptimizerChainFactory;
 use SplFileInfo;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
+use Contao\CoreBundle\Framework\ContaoFramework;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -17,7 +18,7 @@ use Symfony\Component\Finder\Finder;
  * Class OptimizeImagesCommand
  * @package Nerdlichter\ImageOptimizerBundle\Command
  */
-class OptimizeImagesCommand extends ContainerAwareCommand
+class OptimizeImagesCommand extends Command
 {
     /**
      * @var string
@@ -51,6 +52,17 @@ class OptimizeImagesCommand extends ContainerAwareCommand
      * @var bool
      */
     private $backup;
+    /**
+     * @var ContaoFramework
+     */
+    private $framework;
+
+    public function __construct(ContaoFramework $framework)
+    {
+        $this->framework = $framework;
+
+        parent::__construct();
+    }
 
     protected function configure()
     {
@@ -73,9 +85,13 @@ class OptimizeImagesCommand extends ContainerAwareCommand
      */
     public function run(InputInterface $input, OutputInterface $output)
     {
+        $this->framework->initialize();
+
         $path = $this->init($input, $output);
         $this->process($path);
         $this->printInformation();
+
+        return 0;
     }
 
     /**

--- a/src/Resources/config/commands.yml
+++ b/src/Resources/config/commands.yml
@@ -7,3 +7,13 @@ services:
     # this means you cannot fetch services directly from the container via $container->get()
     # if you need to do this, you can override this setting on individual services
     public: true
+
+  _instanceof:
+    Contao\CoreBundle\Framework\FrameworkAwareInterface:
+      calls:
+      - ['setFramework', ['@contao.framework']]
+
+  nl_image.command.optimize:
+    class: Nerdlichter\ImageOptimizerBundle\Command\OptimizeImagesCommand
+    arguments: 
+      - '@contao.framework'


### PR DESCRIPTION
#1 command is not available in contao 4.9
use `Symfony\Component\Console\Command\Command;`
instead of `Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;`
as it is deprecated since — Symfony 4.2